### PR TITLE
fix: add missing task argument to add_frame

### DIFF
--- a/1.collect_data.ipynb
+++ b/1.collect_data.ipynb
@@ -372,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -437,14 +437,15 @@
     "        wrist_image = np.array(wrist_image)\n",
     "        if record_flag:\n",
     "            # Add the frame to the dataset\n",
-    "            dataset.add_frame( {\n",
+    "            dataset.add_frame( \n",
+    "                frame={\n",
     "                    \"observation.image\": agent_image,\n",
     "                    \"observation.wrist_image\": wrist_image,\n",
     "                    \"observation.state\": ee_pose, \n",
     "                    \"action\": joint_q,\n",
     "                    \"obj_init\": PnPEnv.obj_init_pose,\n",
-    "                    \"task\": TASK_NAME,\n",
-    "                }\n",
+    "                },\n",
+    "                task=TASK_NAME\n",
     "            )\n",
     "        PnPEnv.render(teleop=True)"
    ]


### PR DESCRIPTION
## 변경 사항
- collect_data.ipynb 내 `dataset.add_frame` 호출부에 `task` 인자 추가

## 원인
- `add_frame` (frame) → (frame, task, timestamp)로 변경됨

Closes #4
